### PR TITLE
preprocess: load recursively and convert formats

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -40,16 +40,16 @@ def parse_args():
 def encode_and_save_latent(rave, audio_data, audio_file, latent_folder, latent_length):
     with torch.no_grad():
 
-        x = torch.from_numpy(audio_data).reshape(1, 1, -1).float()
+        x = torch.from_numpy(audio_data).reshape(1, 1, -1)
 
-        print("Audio",audio_file)
+        print("Audio", audio_file)
 
         if device.type != 'cpu':
             x = x.to(device)
             rave = rave.to(device)
 
         z = rave.encode(x)
-        print("Encoded into latent",z.shape)
+        print("Encoded into latent", z.shape)
 
         z_mean = z.mean()
         z_std = z.std()
@@ -112,7 +112,7 @@ def main():
 
         pbar.set_description(os.path.relpath(audio_file, args.audio_folder))
         for (i, chunk_bytes) in enumerate(chunks):
-            cropped_data = np.frombuffer(chunk_bytes, dtype=np.int16)
+            cropped_data = np.frombuffer(chunk_bytes, dtype=np.int16).astype(np.float32) / 2**15
             output_file = f"{dir_hash}_{base_name}_part{i:03d}.wav"
             pbar.set_postfix_str(f"chunk:{i}")
             encode_and_save_latent(rave, cropped_data, output_file, args.latent_folder, args.latent_length)

--- a/preprocess.py
+++ b/preprocess.py
@@ -11,6 +11,12 @@ import os
 import numpy as np
 from torch.utils.data import Dataset
 from pydub import AudioSegment
+from pathlib import Path
+import subprocess
+from typing import Iterable
+import hashlib # for hashing paths
+from tqdm import tqdm
+
 
 if torch.cuda.is_available():
     device = torch.device("cuda:0")
@@ -26,6 +32,9 @@ def parse_args():
     parser.add_argument('--sample_rate', type=int, default=48000, choices=[44100, 48000], help='Sample rate for the audio files.')
     parser.add_argument('--latent_length', type=int, default=4096, choices=[2048, 4096, 8192, 16384], help='Length of saved RAVE latents.')
     parser.add_argument('--latent_folder', type=str, default='latents', help='Path to the folder where RAVE latent files will be saved.')
+    parser.add_argument('--extensions', type=str, nargs="+",
+                        default=['wav', 'opus', 'mp3', 'aac', 'flac'],
+                        help='Extensions to search for in audio_folder')
     return parser.parse_args()
 
 def encode_and_save_latent(rave, audio_data, audio_file, latent_folder, latent_length):
@@ -57,63 +66,55 @@ def encode_and_save_latent(rave, audio_data, audio_file, latent_folder, latent_l
 
         np.save(os.path.join(latent_folder, audio_file[:-4] + '.npy'), z)
 
+# from RAVE
+def load_audio_chunk(path: str, n_signal: int,
+                     sr: int) -> Iterable[np.ndarray]:
+    process = subprocess.Popen(
+        [
+            'ffmpeg', '-hide_banner', '-loglevel', 'panic', '-i', path, '-ac',
+            '1', '-ar',
+            str(sr), '-f', 's16le', '-'
+        ],
+        stdout=subprocess.PIPE,
+    )
+
+    chunk = process.stdout.read(n_signal * 2)
+
+    while len(chunk) == n_signal * 2:
+        yield chunk
+        chunk = process.stdout.read(n_signal * 2)
+
+    process.stdout.close()
+
 def main():
     args = parse_args()
 
     os.makedirs(args.latent_folder, exist_ok=True)
-    
+
     rave = torch.jit.load(args.rave_model).to(device)
 
-    audio_files = [f for f in os.listdir(args.audio_folder) if f.endswith(".wav")]
+    crop_samples = args.latent_length * 2048
 
-    if args.sample_rate == 44100:
-        if args.latent_length == 2048:
-            crop_duration = 96 * 1000
+    audio_folder = Path(args.audio_folder)
+    audio_files = [f for ext in args.extensions for f in audio_folder.rglob(f'*.{ext}')]
 
-        elif args.latent_length == 4096:
-            crop_duration = 192 * 1000
+    pbar = tqdm(audio_files)
+    for audio_file in pbar:
+        base_name = os.path.splitext(os.path.basename(audio_file))[0]
+        # hash dirname to avoid conflicts between same filenames in different dirs
+        hasher = hashlib.new('md5')
+        hasher.update(os.path.dirname(audio_file).encode())
+        dir_hash = hasher.hexdigest()
 
-        elif args.latent_length == 8192:
-            crop_duration = 384 * 1000
+        chunks = load_audio_chunk(os.path.abspath(audio_file),
+                                  n_signal=crop_samples,
+                                  sr=args.sample_rate)
 
-        elif args.latent_length == 16384:
-            crop_duration = 768 * 1000
-
-    if args.sample_rate == 48000:
-        if args.latent_length == 2048:
-            crop_duration = 88 * 1000
-
-        elif args.latent_length == 4096:
-            crop_duration = 176 * 1000
-
-        elif args.latent_length == 8192:
-            crop_duration = 352 * 1000
-
-        elif args.latent_length == 16384:
-            crop_duration = 704 * 1000
-
-    for audio_file in audio_files:
-        full_path = os.path.join(args.audio_folder, audio_file)
-        base_name = os.path.splitext(audio_file)[0]
-        audio = AudioSegment.from_wav(full_path)
-
-        # Set the sample rate
-        audio = audio.set_frame_rate(args.sample_rate)
-        audio = audio.set_channels(1)
-
-        file_duration = len(audio)  # Duration in milliseconds
-        num_segments = file_duration // crop_duration
-
-        for i in range(num_segments):
-            start_time = i * crop_duration
-            end_time = start_time + crop_duration
-            cropped_audio = audio[int(start_time):int(end_time)]
-
-            output_file = f"{base_name}_part{i:03d}.wav"
-
-            # Convert pydub.AudioSegment to numpy array
-            cropped_data = np.array(cropped_audio.get_array_of_samples())
-
+        pbar.set_description(os.path.relpath(audio_file, args.audio_folder))
+        for (i, chunk_bytes) in enumerate(chunks):
+            cropped_data = np.frombuffer(chunk_bytes, dtype=np.int16)
+            output_file = f"{dir_hash}_{base_name}_part{i:03d}.wav"
+            pbar.set_postfix_str(f"chunk:{i}")
             encode_and_save_latent(rave, cropped_data, output_file, args.latent_folder, args.latent_length)
 
     print('Done encoding RAVE latents')


### PR DESCRIPTION
In preprocess.py, search for audio files recursively, and use ffmpeg to convert them. The ffmpeg part was copied from rave, minus the multiprocessing part.
Adds an argument --extensions, to specify which extensions are searched for, with the same default selection as rave.

Fixes #2 
