### PR TITLE
read rave_dim, sample_rate and stereo where possible

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -94,11 +94,14 @@ def generate_audio(model, rave, args, seed):
 
         y = y.reshape(-1).detach().numpy()
 
-        y_left  = y[:len(y)//2]
-        y_right = y[len(y)//2:]
+        if rave.stereo:
+            y_l = y[:len(y)//2]
+            y_r = y[len(y)//2:]
+            y = np.stack((y_l, y_r), axis=-1)
 
-        y_stereo = np.stack((y_left, y_right), axis=-1)
-        sf.write(f'{args.output_path}/rave-latent_diffusion_seed{seed}_{args.name}_{rave_model_name}.wav', y_stereo, args.sample_rate)
+        path = f'{args.output_path}/rave-latent_diffusion_seed{seed}_{args.name}_{rave_model_name}.wav'
+        print(f"Writing {path}")
+        sf.write(path, y, args.sample_rate)
 
 # Generate audio by slerping between two diffusion generated RAVE latents.
 def interpolate_seeds(model, rave, args, seed):
@@ -140,14 +143,16 @@ def interpolate_seeds(model, rave, args, seed):
         rave = rave.cpu()
         diff = diff.cpu()
         y = rave.decode(diff)
-
         y = y.reshape(-1).detach().numpy()
 
-        y_left  = y[:len(y)//2]
-        y_right = y[len(y)//2:]
+        if rave.stereo:
+            y_l = y[:len(y)//2]
+            y_r = y[len(y)//2:]
+            y = np.stack((y_l, y_r), axis=-1)
 
-        y_stereo = np.stack((y_left, y_right), axis=-1)
-        sf.write(f'{args.output_path}/rave-latent_diffusion_seed{seed}_{args.name}_{rave_model_name}_slerp.wav', y_stereo, args.sample_rate)
+        path = f'{args.output_path}/rave-latent_diffusion_seed{seed}_{args.name}_{rave_model_name}_slerp.wav'
+        print(f"Writing {path}")
+        sf.write(path, y, args.sample_rate)
 
 # Main function sets up the models and generates the audio.
 def main():

--- a/generate.py
+++ b/generate.py
@@ -32,7 +32,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Generate RAVE latents using diffusion model.")
     parser.add_argument("--model_path", type=str, required=True, default=None, help="Path to the pretrained diffusion model checkpoint.")
     parser.add_argument("--rave_model", type=str, required=True, default=None, help="Path to the pretrained RAVE model (.ts).")
-    parser.add_argument("--sample_rate", type=int, default=48000, choices=[44100, 48000], help="Sample rate for generated audio. Should match samplerate of RAVE model.")
+    parser.add_argument("--sample_rate", type=int, default=None, choices=[44100, 48000], help="Sample rate for generated audio. Should match samplerate of RAVE model.")
     parser.add_argument("--diffusion_steps", type=int, default=100, help="Number of steps for denoising diffusion.")
     parser.add_argument("--seed", type=int, default=random.randint(0,2**31-1), help="Random seed for generation.")
     parser.add_argument('--latent_length', type=int, default=4096, choices=[2048, 4096, 8192, 16384], help='Length of generated RAVE latents.')
@@ -155,6 +155,11 @@ def main():
 
     rave = torch.jit.load(args.rave_model).to(device)
     rave_dims = get_latent_dim(rave)
+
+    if not args.sample_rate:
+        msg = "RAVE model doesn't store its sample rate. --sample_rate is required."
+        assert hasattr(rave, "sr"), msg
+        args.sample_rate = rave.sr
 
     ### GENERATING WITH .PT FILE DIFFUSION
     model = DiffusionModel(

--- a/generate.py
+++ b/generate.py
@@ -75,14 +75,10 @@ def generate_audio(model, rave, args, seed):
 
         model.eval()
 
-        num_steps = 1
-        with tqdm(total=num_steps) as pbar:
-            for i in range(num_steps):
-                ### GENERATING WITH .PT FILE
-                diff = model.sample(noise, num_steps=args.diffusion_steps)
-                # diff = model(noise)
-                # noise = diff
-                pbar.update(1)
+        ### GENERATING WITH .PT FILE
+        diff = model.sample(noise, num_steps=args.diffusion_steps, show_progress=True)
+        # diff = model(noise)
+        # noise = diff
 
         diff_mean = diff.mean()
         diff_std = diff.std()
@@ -90,13 +86,14 @@ def generate_audio(model, rave, args, seed):
 
         rave = rave.cpu()
         diff = diff.cpu()
+        print("Decoding using RAVE Model...")
         y = rave.decode(diff)
-
         y = y.reshape(-1).detach().numpy()
 
         if rave.stereo:
             y_l = y[:len(y)//2]
             y_r = y[len(y)//2:]
+
             y = np.stack((y_l, y_r), axis=-1)
 
         path = f'{args.output_path}/rave-latent_diffusion_seed{seed}_{args.name}_{rave_model_name}.wav'
@@ -128,13 +125,9 @@ def interpolate_seeds(model, rave, args, seed):
 
         model.eval()
 
-        num_steps = 1
-        with tqdm(total=num_steps) as pbar:
-            for i in range(num_steps):
-                diff1 = model.sample(noise1, num_steps=args.diffusion_steps)
-                diff2 = model.sample(noise2, num_steps=args.diffusion_steps)
-                diff = slerp(torch.linspace(0., args.lerp_factor, z_length).to(device), diff1, diff2)
-                pbar.update(1)
+        diff1 = model.sample(noise1, num_steps=args.diffusion_steps, show_progress=True)
+        diff2 = model.sample(noise2, num_steps=args.diffusion_steps, show_progress=True)
+        diff = slerp(torch.linspace(0., args.lerp_factor, z_length).to(device), diff1, diff2)
 
         diff_mean = diff.mean()
         diff_std = diff.std()
@@ -142,6 +135,7 @@ def interpolate_seeds(model, rave, args, seed):
 
         rave = rave.cpu()
         diff = diff.cpu()
+        print("Decoding using RAVE Model...")
         y = rave.decode(diff)
         y = y.reshape(-1).detach().numpy()
 

--- a/train.py
+++ b/train.py
@@ -36,6 +36,8 @@ class RaveDataset(Dataset):
             z = torch.from_numpy(z).float().squeeze()
             self.latent_data.append(z)
 
+        self.latent_size = self.latent_data[0].shape[0]
+
     def __len__(self):
         return len(self.latent_data)
 
@@ -55,7 +57,6 @@ def parse_args():
     parser.add_argument("--accumulation_steps", type=int, default=2, help="Number of gradient accumulation steps.")
     parser.add_argument("--save_interval", type=int, default=50, help="Interval (number of epochs) at which to save the model.")
     parser.add_argument("--finetune", type=bool, default=False, help="Finetune model.")
-    parser.add_argument("--rave_dims", type=int, choices=[4, 8, 16, 32, 64, 128], default=16, help="Number of hidden dimensions in RAVE model.")
     return parser.parse_args()
 
 def set_seed(seed=664):
@@ -110,6 +111,8 @@ def main():
     train_dataset = RaveDataset(latent_folder, train_latent_files)
     val_dataset = RaveDataset(latent_folder, val_latent_files)
 
+    rave_dims = train_dataset.latent_size
+
     batch_size = args.batch_size
 
     train_data_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True, num_workers=8, pin_memory=True)
@@ -117,7 +120,7 @@ def main():
 
     model = DiffusionModel(
         net_t=UNetV0,
-        in_channels=args.rave_dims,
+        in_channels=rave_dims,
         channels=[256, 256, 256, 256, 512, 512, 512, 768, 768],
         factors=[1, 4, 4, 4, 2, 2, 2, 2, 2],
         items=[1, 2, 2, 2, 2, 2, 2, 4, 4],


### PR DESCRIPTION
Some small changes to read settings from RAVE models when possible, so to avoid unnecessary cli arguments.
The only other thing I would like to do in this direction is to read the minimum latent_size of a trained diffusion model, so that we could only provide length_mul, but I couldn't figure out how.

- rave_dims: read from model, remove argument
Read rave_dims from RAVE model, like nn_tilde does (rave.decode_params[0]).

- generate.py: read sample_rate from rave by default if supported (rave v2)
RAVE v2 models store their sample_rate as rave.sr. Since it doesn't make sense to choose a different one, read sample_rate from rave if possible, otherwise require the --sample_rate argument

- generate.py: split stereo only if rave is stereo
RAVE stores rave.stereo = True if exported with --stereo. Check this value before splitting decoded audio in left and right, so that the model can work also with mono RAVE models.

- generate: more informative progress bar and messages
Instead of a progress bar with 1 step, show the progress bar from `sample`, which shows diffusion steps. In my opinion it gives a more meaningful sense of progress through the task.
